### PR TITLE
ci: sign and upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
       - beta
       - main
       - renovate/**
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   ci-optimization:
@@ -20,7 +22,7 @@ jobs:
   build:
     needs: ci-optimization
     name: Build iOS (simulator)
-    runs-on: macos-26 # change back to macos-latest once v26 is default
+    runs-on: macos-26 # TODO: change back to macos-latest once v26 is default (https://github.com/actions/runner-images/blob/main/README.md#available-images)
 
     steps:
       - name: Checkout repository
@@ -36,4 +38,76 @@ jobs:
       - name: Build workspace on iOS Simulator
         run: |
           set -o pipefail
-          xcodebuild -workspace vibetype.xcworkspace -scheme vibetype -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Release clean build | xcpretty
+          xcodebuild -workspace vibetype.xcworkspace \
+            -scheme vibetype \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
+            -configuration Release \
+            clean build | xcpretty
+  release:
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    name: Sign and release to TestFlight
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
+
+      - name: Install CocoaPods
+        run: |
+          sudo gem install cocoapods xcpretty
+
+      - name: Import distribution certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo "$CERTIFICATE_BASE64" | base64 --decode -o "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+      - name: Install provisioning profile
+        env:
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode -o ~/Library/MobileDevice/Provisioning\ Profiles/vibetype.mobileprovision
+
+      - name: Archive app
+        run: |
+          set -o pipefail
+          xcodebuild -workspace vibetype.xcworkspace \
+            -scheme vibetype \
+            -configuration Release \
+            -archivePath "$RUNNER_TEMP/vibetype.xcarchive" \
+            archive | xcpretty
+
+      - name: Export IPA
+        run: |
+          set -o pipefail
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/vibetype.xcarchive" \
+            -exportPath "$RUNNER_TEMP/export" \
+            -exportOptionsPlist ExportOptions.plist | xcpretty
+
+      - name: Upload to TestFlight
+        env:
+          API_KEY_ID: ${{ secrets.APPSTORE_CONNECT_API_KEY_ID }}
+          API_KEY_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_API_KEY_ISSUER_ID }}
+          API_KEY_PRIVATE_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$API_KEY_PRIVATE_KEY" > ~/.appstoreconnect/private_keys/AuthKey_${API_KEY_ID}.p8
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$RUNNER_TEMP/export/vibetype.ipa" \
+            --apiKey "$API_KEY_ID" \
+            --apiIssuer "$API_KEY_ISSUER_ID"

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>destination</key>
+    <string>upload</string>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>signingCertificate</key>
+    <string>Apple Distribution</string>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>si.maev.twa</key>
+        <string>vibetype Distribution</string>
+    </dict>
+    <key>teamID</key>
+    <string>NJWSWLWL24</string>
+    <key>uploadSymbols</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
This pull request introduces an automated release workflow for iOS builds, enabling the app to be signed and uploaded to TestFlight whenever a version tag is pushed. It adds a new job to the GitHub Actions CI pipeline, manages code signing securely using secrets, and includes a new `ExportOptions.plist` file for configuring the export process.
